### PR TITLE
Added BUILDPACK_LOG_FILE default

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1,3 +1,8 @@
+# Buildpack defaults
+# ---------------
+
+export BUILDPACK_LOG_FILE=${BUILDPACK_LOG_FILE:-/dev/null}
+
 # Standard Output
 # ---------------
 


### PR DESCRIPTION
The prevents each buildpack from including the same `BUILDPACK_LOG_FILE=${...}` code, which is required for tests and platforms other than Heroku.
