### PR TITLE
Speed up the Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
+dist: trusty
+sudo: false
 language: bash
-before_install:
-  - sudo add-apt-repository ppa:duggan/bats --yes
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq bats
 script:
   - bats tests.bats


### PR DESCRIPTION
Switches from the deprecated Travis precise image to their trusty image, where bats is already installed. This means sudo isn't required so the container (`sudo: false`) infra can be used instead, which has a boot time of <5s rather than the 30s of the full GCE VMs.

Note that the "Ran for 30 sec" Travis field doesn't include boot/startup time (it's displayed under "Worker information" in the log), so whilst the runtime of this PR looks about the same as master, the wall time is actually halved.

This also avoids any fallout from when Travis starts switching people over to trusty by default:
https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming