### PR TITLE
Fix test for set_default_env

### DIFF
--- a/tests.bats
+++ b/tests.bats
@@ -119,7 +119,7 @@ teardown() {
   result2="$(cat $EXPORT_PATH)"
 
   [ "$result1" = 'export hello=${hello:-world}' ]
-  [ "$result1" = 'export hello=${hello:-world}' ]
+  [ "$result2" = 'export hello=${hello:-world}' ]
 }
 
 @test "nowms somewhat accurate" {


### PR DESCRIPTION
Before `result1` was being checked twice, and `result2` not at all.